### PR TITLE
Add Room TBA

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,4 +461,5 @@ Open-source campus room finder for UPLB students: search rooms, buildings, sched
 
 - [Website](https://room-tba.uplbtools.me)
 - [GitHub](https://github.com/uplbtools/room-tba)
-- Author: [@smmariquit](https://github.com/smmariquit)
+- Maintainer: [@smmariquit](https://github.com/smmariquit)
+- Contributors: [@Kenramiscal1106](https://github.com/Kenramiscal1106), [@klnwlks](https://github.com/klnwlks)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A curated compilation of exceptional open-source projects crafted by talented Fi
   - [use-postal-ph](#use-postal-ph)
   - [Leaves.PH](#leavesph)
   - [dataviz.ph](#datavizph)
+  - [Room TBA](#room-tba)
 ---
 
 ## Vue Stripe
@@ -453,3 +454,11 @@ Animated bubble, line, rank, and choropleth charts of Philippine public data: DP
 - [Website](https://dataviz.ph)
 - [GitHub](https://github.com/xmpuspus/dataviz-ph)
 - Author: [@xmpuspus](https://github.com/xmpuspus)
+
+## Room TBA
+
+Open-source campus room finder for UPLB students: search rooms, buildings, schedules, and events on an interactive map with offline PWA support.
+
+- [Website](https://room-tba.uplbtools.me)
+- [GitHub](https://github.com/uplbtools/room-tba)
+- Author: [@smmariquit](https://github.com/smmariquit)

--- a/README.md
+++ b/README.md
@@ -461,5 +461,4 @@ Open-source campus room finder for UPLB students: search rooms, buildings, sched
 
 - [Website](https://room-tba.uplbtools.me)
 - [GitHub](https://github.com/uplbtools/room-tba)
-- Maintainer: [@smmariquit](https://github.com/smmariquit)
-- Contributors: [@Kenramiscal1106](https://github.com/Kenramiscal1106), [@klnwlks](https://github.com/klnwlks)
+- Author: [@smmariquit](https://github.com/smmariquit)

--- a/data.json
+++ b/data.json
@@ -2,7 +2,7 @@
   "metadata": {
     "version": "1.0.0",
     "lastUpdated": "2024-01-01",
-    "totalProjects": 46,
+    "totalProjects": 47,
     "description": "A curated compilation of exceptional open-source projects crafted by talented Filipino authors and maintainers"
   },
   "projects": [
@@ -1609,6 +1609,47 @@
         "documentation": null
       },
       "organization": null,
+      "addedDate": null,
+      "stars": null
+    },
+    {
+      "id": "room-tba",
+      "name": "Room TBA",
+      "slug": "room-tba",
+      "description": "Open-source campus room finder for UPLB students: search rooms, buildings, schedules, and events on an interactive map with offline PWA support.",
+      "iconUrl": null,
+      "bannerUrl": null,
+      "category": "application",
+      "tags": [
+        "philippines",
+        "uplb",
+        "campus",
+        "map",
+        "pwa",
+        "geospatial",
+        "education",
+        "open-source"
+      ],
+      "technologies": [
+        "Astro",
+        "Svelte",
+        "MapLibre",
+        "Drizzle ORM",
+        "PGlite",
+        "Bun"
+      ],
+      "author": {
+        "name": "smmariquit",
+        "github": "https://github.com/smmariquit",
+        "twitter": null
+      },
+      "links": {
+        "website": "https://room-tba.uplbtools.me",
+        "github": "https://github.com/uplbtools/room-tba",
+        "npm": null,
+        "documentation": null
+      },
+      "organization": "uplbtools",
       "addedDate": null,
       "stars": null
     }


### PR DESCRIPTION
## Summary
Adds [Room TBA](https://room-tba.uplbtools.me), an open-source, map-first campus room finder for UPLB students (schedules, jeepney routes, offline PWA).

- Live: https://room-tba.uplbtools.me
- Code: https://github.com/uplbtools/room-tba
- Maintainer: @smmariquit; contributors @Kenramiscal1106, @klnwlks (plus campus data volunteers in repo README)
- License: MIT

## Test plan
- [x] Entry follows existing section format (Website, GitHub, credits)
- [x] Table of contents updated